### PR TITLE
Updated load_pem() to output consistent Dict[List]

### DIFF
--- a/src/refined/resource_management/loaders.py
+++ b/src/refined/resource_management/loaders.py
@@ -160,6 +160,9 @@ def load_pem(pem_file: str, is_test: bool = False, max_cands: Optional[int] = No
             if max_cands:
                 pem[line["surface_form"]] = list(pem[line["surface_form"]].items())[:max_cands]
                 # pem[line["surface_form"]] = line["qcode_probs"][:max_cands]
+            else:
+                pem[line["surface_form"]] = list(pem[line["surface_form"]].items())
+
             line_num += 1
             if is_test and line_num > 10000:
                 break


### PR DESCRIPTION
if `max_cands` is not specified, `load_pem()` will output `Dict[Dict]` instead of `Dict[List]`, causing the `pem.lmdb` built to have unexpected type by the candidate generator (`get_candidates()`)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
