### PR TITLE
Fix a bug to cause top k results having the same title

### DIFF
--- a/src/refined/inference/processor.py
+++ b/src/refined/inference/processor.py
@@ -157,7 +157,6 @@ class Refined(object):
         :return: a list of spans with predictions attached to each span (sorted by start indices)
                  or a list of mention dictionary (in distant supervision dataset format) when ds_format is True.
         """
-        print("Processing text: ", text)
         all_spans = []
         if spans is not None:
             doc = Doc.from_text_with_spans(


### PR DESCRIPTION
Solve #16 

Solved a bug in titles of top k entity ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.