### PR TITLE
fixed redirects due to wrong parsing wikipedia_page_id sql

### DIFF
--- a/src/refined/offline_data_generation/process_wiki.py
+++ b/src/refined/offline_data_generation/process_wiki.py
@@ -61,7 +61,7 @@ def build_redirects(args=None):
 def generate_wiki_id_to_title(page_sql_gz_filepath: str, output_dir: str) -> Dict[str, str]:
     # page_id, namespace, title, restrictions, redirect, new, random, touched, links, latest, len, content_model, lang
     page_id_to_title: Dict[str, str] = dict()
-    pattern = re.compile("([0-9]+),([0-9]+),(.+),(.+),([0-9]+),([0-9]+),(.+),(.+),(.+),([0-9]+),([0-9]+),(.+),(.+)")
+    pattern = re.compile("([0-9]+),([0-9]+),'(.+)',([0-9]+),([0-9]+),([0-9\.]+),'(.+)','(.+)',([0-9]+),([0-9]+),'(.+)',(.+)")
     wiki_id_to_title_file = open(f'{output_dir}/wiki_id_to_title.json', 'w')
     with gzip.open(page_sql_gz_filepath, 'r') as f:
         for line in tqdm(f, total=5775):
@@ -76,11 +76,10 @@ def generate_wiki_id_to_title(page_sql_gz_filepath: str, output_dir: str) -> Dic
                 if m is None:
                     continue
                 groups = m.groups()
-                page_id, namespace, title, restrictions, redirect, new, random, touched, links, \
+                page_id, namespace, title, redirect, new, random, touched, links, \
                     latest, length, content_model, lang = groups
                 if not namespace == '0':
                     continue
-                title = title[1:-1]
                 page_id_to_title[page_id] = title
                 wiki_id_to_title_file.write(json.dumps({'wiki_page_id': page_id, 'wiki_title': title}) + '\n')
     wiki_id_to_title_file.close()


### PR DESCRIPTION
*Issue #, if available:*

Wrongly parse `152750,0,'Tricity,_Poland',0,0,0.8858758871312029,'20230919232330','20230919232347',1176139506,26946,'wikitext',NULL`

due to matching pattern.

*Description of changes:*

Fixed matching pattern.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
